### PR TITLE
cleanup interface to reduce the number of functions

### DIFF
--- a/src/helper_modules/POPCExplicitForceControl.cpp
+++ b/src/helper_modules/POPCExplicitForceControl.cpp
@@ -29,7 +29,7 @@ void POPCExplicitForceControl::disable() {
 
 Vector3d POPCExplicitForceControl::computePassivitySaturatedForce(
 	const Vector3d& fd, const Vector3d& fs, const Vector3d& vcl,
-	const Vector3d& vr, const double kv_force, const double k_feedforward) {
+	const Vector3d& vr, const Matrix3d kv_force, const double k_feedforward) {
 	if (!_is_enabled) {
 		return vcl - kv_force * vr;
 	}

--- a/src/helper_modules/POPCExplicitForceControl.h
+++ b/src/helper_modules/POPCExplicitForceControl.h
@@ -27,7 +27,7 @@ public:
 	Vector3d computePassivitySaturatedForce(
 		const Vector3d& fd, const Vector3d& fs,
 		const Vector3d& vcl, const Vector3d& vr,
-		const double kv_force = 0, const double k_feedforward = 0);
+		const Matrix3d kv_force = Matrix3d::Zero(), const double k_feedforward = 0);
 
 private:
 

--- a/src/helper_modules/Sai2PrimitivesCommonDefinitions.h
+++ b/src/helper_modules/Sai2PrimitivesCommonDefinitions.h
@@ -1,0 +1,17 @@
+#ifndef SAI2_PRIMITIVES_COMMON_DEFINITIONS_H_
+#define SAI2_PRIMITIVES_COMMON_DEFINITIONS_H_
+
+namespace Sai2Primitives
+{
+
+struct PIDGains {
+	double kp;
+	double kv;
+	double ki;
+
+	PIDGains(double kp, double kv, double ki) : kp(kp), kv(kv), ki(ki) {}
+};
+
+}
+
+#endif // SAI2_PRIMITIVES_COMMON_DEFINITIONS_H_

--- a/src/tasks/MotionForceTask.cpp
+++ b/src/tasks/MotionForceTask.cpp
@@ -11,31 +11,25 @@
 using namespace std;
 using namespace Eigen;
 
-namespace Sai2Primitives
-{
+namespace Sai2Primitives {
 
+namespace {
+const double MAX_FEEDBACK_FORCE_FORCE_CONTROLLER = 20.0;
+const double MAX_FEEDBACK_MOMENT_FORCE_CONTROLLER = 10.0;
+}  // namespace
 
-MotionForceTask::MotionForceTask(Sai2Model::Sai2Model* robot, 
-			const string link_name, 
-			const Affine3d control_frame,
-			const double loop_timestep) :
-	MotionForceTask(robot, link_name, control_frame.translation(), control_frame.linear(), loop_timestep) {}
-
-MotionForceTask::MotionForceTask(Sai2Model::Sai2Model* robot, 
-			const string link_name, 
-			const Vector3d pos_in_link, 
-			const Matrix3d rot_in_link,
-			const double loop_timestep)
-{
-
+MotionForceTask::MotionForceTask(
+	std::shared_ptr<Sai2Model::Sai2Model> robot, const string& link_name,
+	const Affine3d& compliant_frame,
+	const bool is_force_motion_parametrization_in_compliant_frame,
+	const double loop_timestep) {
 	_loop_timestep = loop_timestep;
-	Affine3d control_frame = Affine3d::Identity();
-	control_frame.linear() = rot_in_link;
-	control_frame.translation() = pos_in_link;
 
 	_robot = robot;
 	_link_name = link_name;
-	_control_frame = control_frame;
+	_compliant_frame = compliant_frame;
+	_is_force_motion_parametrization_in_compliant_frame =
+		is_force_motion_parametrization_in_compliant_frame;
 
 	int dof = _robot->dof();
 
@@ -45,80 +39,64 @@ MotionForceTask::MotionForceTask(Sai2Model::Sai2Model* robot,
 	_POPC_force.reset(new POPCExplicitForceControl(_loop_timestep));
 
 	// motion
-	_current_position = _robot->position(_link_name, _control_frame.translation());
+	_current_position =
+		_robot->position(_link_name, _compliant_frame.translation());
 	_current_orientation = _robot->rotation(_link_name);
 
 	// default values for gains and velocity saturation
-	_kp_pos = 50.0;
-	_kv_pos = 14.0;
-	_ki_pos = 0.0;
-	_kp_ori = 50.0;
-	_kv_ori = 14.0;
-	_ki_ori = 0.0;
+	setPosControlGains(50.0, 14.0, 0.0);
+	setOriControlGains(50.0, 14.0, 0.0);
+	setForceControlGains(0.7, 10.0, 1.3);
+	setMomentControlGains(0.7, 10.0, 1.3);
 
-	_use_isotropic_gains_position = true;
-	_use_isotropic_gains_orientation = true;
-	_kp_pos_mat = Matrix3d::Zero();
-	_kv_pos_mat = Matrix3d::Zero();
-	_ki_pos_mat = Matrix3d::Zero();
-	_kp_ori_mat = Matrix3d::Zero();
-	_kv_ori_mat = Matrix3d::Zero();
-	_ki_ori_mat = Matrix3d::Zero();
-
-	_kp_force = 0.7;
-	_kv_force = 10.0;
-	_ki_force = 1.3;
-	_kp_moment = 0.7;
-	_kv_moment = 10.0;
-	_ki_moment = 1.3;
-
-	_use_velocity_saturation_flag = false;
-	_linear_saturation_velocity = 0.3;
-	_angular_saturation_velocity = M_PI/3;
+	disableVelocitySaturation();
 
 	_k_ff = 1.0;
 
-	// initialize matrices sizes
-	_jacobian.setZero(6,dof);
-	_projected_jacobian.setZero(6,dof);
-	_prev_projected_jacobian.setZero(6,dof);
-	_Lambda.setZero(6,6);
-	_Lambda_modified.setZero(6,6);
-	_Jbar.setZero(dof,6);
-	_N.setZero(dof,dof);
-	_N_prec = MatrixXd::Identity(dof,dof);
+	parametrizeForceMotionSpaces(0);
 
-	_URange_pos = MatrixXd::Identity(3,3);
-	_URange_ori = MatrixXd::Identity(3,3);
-	_URange = MatrixXd::Identity(6,6);
+	// initialize matrices sizes
+	_jacobian.setZero(6, dof);
+	_projected_jacobian.setZero(6, dof);
+	_prev_projected_jacobian.setZero(6, dof);
+	_Lambda.setZero(6, 6);
+	_Lambda_modified.setZero(6, 6);
+	_Jbar.setZero(dof, 6);
+	_N.setZero(dof, dof);
+	_N_prec = MatrixXd::Identity(dof, dof);
+
+	_URange_pos = MatrixXd::Identity(3, 3);
+	_URange_ori = MatrixXd::Identity(3, 3);
+	_URange = MatrixXd::Identity(6, 6);
 
 	_pos_dof = 3;
 	_ori_dof = 3;
 
 #ifdef USING_OTG
-	_use_interpolation_flag = true; 
-	_otg = new OTG_posori(_current_position, _current_orientation, _loop_timestep);
+	_use_interpolation_flag = true;
+	_otg =
+		new OTG_posori(_current_position, _current_orientation, _loop_timestep);
 
 	_otg->setMaxLinearVelocity(0.3);
 	_otg->setMaxLinearAcceleration(1.0);
 	_otg->setMaxLinearJerk(3.0);
 
-	_otg->setMaxAngularVelocity(M_PI/3);
+	_otg->setMaxAngularVelocity(M_PI / 3);
 	_otg->setMaxAngularAcceleration(M_PI);
-	_otg->setMaxAngularJerk(3*M_PI);
+	_otg->setMaxAngularJerk(3 * M_PI);
 #endif
 	reInitializeTask();
 }
 
-void MotionForceTask::reInitializeTask()
-{
+void MotionForceTask::reInitializeTask() {
 	int dof = _robot->dof();
 
 	// motion
-	_current_position = _robot->position(_link_name, _control_frame.translation());
-	_desired_position = _robot->position(_link_name, _control_frame.translation());
+	_current_position =
+		_robot->position(_link_name, _compliant_frame.translation());
+	_desired_position = _current_position;
 	_current_orientation = _robot->rotation(_link_name);
-	_desired_orientation = _robot->rotation(_link_name);
+	_desired_orientation = _current_orientation;
 
 	_current_velocity.setZero();
 	_desired_velocity.setZero();
@@ -139,56 +117,47 @@ void MotionForceTask::reInitializeTask()
 	_step_desired_acceleration.setZero();
 	_step_desired_angular_acceleration.setZero();
 
-	_sigma_position = Matrix3d::Identity();
-	_sigma_orientation = Matrix3d::Identity();
-
 	_desired_force.setZero();
 	_sensed_force.setZero();
 	_desired_moment.setZero();
 	_sensed_moment.setZero();
 
-	_integrated_force_error.setZero();
-	_integrated_moment_error.setZero();
-
-	_sigma_force.setZero();
-	_sigma_moment.setZero();
-
-	_closed_loop_force_control = false;
-	_closed_loop_moment_control = false;
+	resetIntegrators();
 
 	_task_force.setZero(6);
 	_unit_mass_force.setZero(6);
 
-#ifdef USING_OTG 
+#ifdef USING_OTG
 	_otg->reInitialize(_current_position, _current_orientation);
 #endif
 }
 
-void MotionForceTask::updateTaskModel(const MatrixXd N_prec)
-{
-	if(N_prec.rows() != N_prec.cols())
-	{
-		throw invalid_argument("N_prec matrix not square in MotionForceTask::updateTaskModel\n");
+void MotionForceTask::updateTaskModel(const MatrixXd N_prec) {
+	if (N_prec.rows() != N_prec.cols()) {
+		throw invalid_argument(
+			"N_prec matrix not square in MotionForceTask::updateTaskModel\n");
 	}
-	if(N_prec.rows() != _robot->dof())
-	{
-		throw invalid_argument("N_prec matrix size not consistent with robot dof in MotionForceTask::updateTaskModel\n");
+	if (N_prec.rows() != _robot->dof()) {
+		throw invalid_argument(
+			"N_prec matrix size not consistent with robot dof in "
+			"MotionForceTask::updateTaskModel\n");
 	}
 
 	_N_prec = N_prec;
 
-	_jacobian = _robot->J(_link_name, _control_frame.translation());
+	_jacobian = _robot->J(_link_name, _compliant_frame.translation());
 	_projected_jacobian = _jacobian * _N_prec;
 
 	_URange_pos = Sai2Model::matrixRangeBasis(_projected_jacobian.topRows(3));
-	_URange_ori = Sai2Model::matrixRangeBasis(_projected_jacobian.bottomRows(3));
+	_URange_ori =
+		Sai2Model::matrixRangeBasis(_projected_jacobian.bottomRows(3));
 
 	_pos_dof = _URange_pos.cols();
 	_ori_dof = _URange_ori.cols();
 
 	_URange.setZero(6, _pos_dof + _ori_dof);
-	_URange.block(0,0,3,_pos_dof) = _URange_pos;
-	_URange.block(3,_pos_dof,3,_ori_dof) = _URange_ori;
+	_URange.block(0, 0, 3, _pos_dof) = _URange_pos;
+	_URange.block(3, _pos_dof, 3, _ori_dof) = _URange_ori;
 
 	Sai2Model::OpSpaceMatrices op_space_matrices =
 		_robot->operationalSpaceMatrices(
@@ -197,73 +166,60 @@ void MotionForceTask::updateTaskModel(const MatrixXd N_prec)
 	_Jbar = op_space_matrices.Jbar;
 	_N = op_space_matrices.N;
 
-	switch(_dynamic_decoupling_type)
-	{
-		case FULL_DYNAMIC_DECOUPLING :
-		{
+	switch (_dynamic_decoupling_type) {
+		case FULL_DYNAMIC_DECOUPLING: {
 			_Lambda_modified = _Lambda;
 			break;
 		}
 
-		case PARTIAL_DYNAMIC_DECOUPLING :
-		{
+		case PARTIAL_DYNAMIC_DECOUPLING: {
 			_Lambda_modified = _Lambda;
-			_Lambda_modified.block(_pos_dof,_pos_dof, _ori_dof, _ori_dof) = MatrixXd::Identity(_ori_dof, _ori_dof);
-			_Lambda_modified.block(0,_pos_dof, _pos_dof, _ori_dof) = MatrixXd::Zero(_pos_dof, _ori_dof);
-			_Lambda_modified.block(_pos_dof,0, _ori_dof, _pos_dof) = MatrixXd::Zero(_ori_dof, _pos_dof);
+			_Lambda_modified.block(_pos_dof, _pos_dof, _ori_dof, _ori_dof) =
+				MatrixXd::Identity(_ori_dof, _ori_dof);
+			_Lambda_modified.block(0, _pos_dof, _pos_dof, _ori_dof) =
+				MatrixXd::Zero(_pos_dof, _ori_dof);
+			_Lambda_modified.block(_pos_dof, 0, _ori_dof, _pos_dof) =
+				MatrixXd::Zero(_ori_dof, _pos_dof);
 			break;
 		}
 
-		case IMPEDANCE :
-		{
-			_Lambda_modified = MatrixXd::Identity(_pos_dof+_ori_dof,_pos_dof+_ori_dof);
+		case IMPEDANCE: {
+			_Lambda_modified =
+				MatrixXd::Identity(_pos_dof + _ori_dof, _pos_dof + _ori_dof);
 			break;
 		}
 
-		case BOUNDED_INERTIA_ESTIMATES :
-		{
+		case BOUNDED_INERTIA_ESTIMATES: {
 			MatrixXd M_BIE = _robot->M();
-			for(int i=0 ; i<_robot->dof() ; i++)
-			{
-				if(M_BIE(i,i) < 0.1)
-				{
-					M_BIE(i,i) = 0.1;
+			for (int i = 0; i < _robot->dof(); i++) {
+				if (M_BIE(i, i) < 0.1) {
+					M_BIE(i, i) = 0.1;
 				}
 			}
 			MatrixXd M_inv_BIE = M_BIE.inverse();
-			MatrixXd Lambda_inv_BIE = _URange.transpose() * _projected_jacobian * (M_inv_BIE * _projected_jacobian.transpose()) * _URange;
+			MatrixXd Lambda_inv_BIE =
+				_URange.transpose() * _projected_jacobian *
+				(M_inv_BIE * _projected_jacobian.transpose()) * _URange;
 			_Lambda_modified = Lambda_inv_BIE.inverse();
 			break;
 		}
 
-		default :
-		{
+		default: {
 			_Lambda_modified = _Lambda;
-			break;			
+			break;
 		}
 	}
-
 }
 
-VectorXd MotionForceTask::computeTorques()
-{
+VectorXd MotionForceTask::computeTorques() {
 	VectorXd task_joint_torques = VectorXd::Zero(_robot->dof());
-	_jacobian = _robot->J(_link_name, _control_frame.translation());
+	_jacobian = _robot->J(_link_name, _compliant_frame.translation());
 	_projected_jacobian = _jacobian * _N_prec;
 
-	// update matrix gains
-	if(_use_isotropic_gains_position)
-	{
-		_kp_pos_mat = _kp_pos * Matrix3d::Identity();
-		_kv_pos_mat = _kv_pos * Matrix3d::Identity();
-		_ki_pos_mat = _ki_pos * Matrix3d::Identity();
-	}
-	if(_use_isotropic_gains_orientation)
-	{
-		_kp_ori_mat = _kp_ori * Matrix3d::Identity();
-		_kv_ori_mat = _kv_ori * Matrix3d::Identity();
-		_ki_ori_mat = _ki_ori * Matrix3d::Identity();
-	}
+	Matrix3d sigma_force = sigmaForce();
+	Matrix3d sigma_moment = sigmaMoment();
+	Matrix3d sigma_position = Matrix3d::Identity() - sigma_force;
+	Matrix3d sigma_orientation = Matrix3d::Identity() - sigma_moment;
 
 	Vector3d force_feedback_related_force = Vector3d::Zero();
 	Vector3d position_related_force = Vector3d::Zero();
@@ -271,12 +227,19 @@ VectorXd MotionForceTask::computeTorques()
 	Vector3d orientation_related_force = Vector3d::Zero();
 
 	// update controller state
-	_current_position = _robot->position(_link_name, _control_frame.translation());
+	_current_position =
+		_robot->position(_link_name, _compliant_frame.translation());
 	_current_orientation = _robot->rotation(_link_name);
-	_current_orientation = _current_orientation * _control_frame.linear(); // orientation of compliant frame in robot frame
-	_orientation_error = Sai2Model::orientationError(_desired_orientation, _current_orientation);
-	_current_velocity = _projected_jacobian.block(0,0,3,_robot->dof()) * _robot->dq();
-	_current_angular_velocity = _projected_jacobian.block(3,0,3,_robot->dof()) * _robot->dq();
+	_current_orientation =
+		_current_orientation *
+		_compliant_frame
+			.linear();	// orientation of compliant frame in robot frame
+	_orientation_error =
+		Sai2Model::orientationError(_desired_orientation, _current_orientation);
+	_current_velocity =
+		_projected_jacobian.block(0, 0, 3, _robot->dof()) * _robot->dq();
+	_current_angular_velocity =
+		_projected_jacobian.block(3, 0, 3, _robot->dof()) * _robot->dq();
 
 	_step_desired_position = _desired_position;
 	_step_desired_velocity = _desired_velocity;
@@ -287,103 +250,133 @@ VectorXd MotionForceTask::computeTorques()
 	_step_desired_angular_acceleration = _desired_angular_acceleration;
 
 	// force related terms
-	if(_closed_loop_force_control)
-	{
+	if (_closed_loop_force_control) {
 		// update the integrated error
-		_integrated_force_error += (_sensed_force - _desired_force) * _loop_timestep;
+		_integrated_force_error +=
+			(_sensed_force - _desired_force) * _loop_timestep;
 
-		// compute the feedback term
-		Vector3d force_feedback_term = - _kp_force * (_sensed_force - _desired_force) - _ki_force * _integrated_force_error;
-		if(force_feedback_term.norm() > 20.0)
-		{
-			force_feedback_term *= 20.0 / force_feedback_term.norm();
+		// compute the feedback term and saturate it
+		Vector3d force_feedback_term =
+			-_kp_force * (_sensed_force - _desired_force) -
+			_ki_force * _integrated_force_error;
+		if (force_feedback_term.norm() > MAX_FEEDBACK_FORCE_FORCE_CONTROLLER) {
+			force_feedback_term *= MAX_FEEDBACK_FORCE_FORCE_CONTROLLER /
+								   force_feedback_term.norm();
 		}
 
 		// compute the final contribution
 		force_feedback_related_force =
 			_POPC_force->computePassivitySaturatedForce(
-				_sigma_force * _desired_force, _sigma_force * _sensed_force,
-				_sigma_force * force_feedback_term,
-				_sigma_force * _current_velocity, _kv_force, _k_ff);
-	}
-	else // open loop force control
+				sigma_force * _desired_force, sigma_force * _sensed_force,
+				sigma_force * force_feedback_term,
+				sigma_force * _current_velocity, _kv_force, _k_ff);
+	} else	// open loop force control
 	{
-		force_feedback_related_force = _sigma_force * (- _kv_force * _current_velocity);
+		force_feedback_related_force =
+			sigma_force * (-_kv_force * _current_velocity);
 	}
 
 	// moment related terms
-	if(_closed_loop_moment_control)
-	{
+	if (_closed_loop_moment_control) {
 		// update the integrated error
-		_integrated_moment_error += (_sensed_moment - _desired_moment) * _loop_timestep;
+		_integrated_moment_error +=
+			(_sensed_moment - _desired_moment) * _loop_timestep;
 
 		// compute the feedback term
-		Vector3d moment_feedback_term = - _kp_moment * (_sensed_moment - _desired_moment) - _ki_moment * _integrated_moment_error;
+		Vector3d moment_feedback_term =
+			-_kp_moment * (_sensed_moment - _desired_moment) -
+			_ki_moment * _integrated_moment_error;
 
 		// saturate the feedback term
-		if(moment_feedback_term.norm() > 10.0)
-		{
-			moment_feedback_term *= 10.0 / moment_feedback_term.norm();
+		if (moment_feedback_term.norm() >
+			MAX_FEEDBACK_MOMENT_FORCE_CONTROLLER) {
+			moment_feedback_term *= MAX_FEEDBACK_MOMENT_FORCE_CONTROLLER /
+									moment_feedback_term.norm();
 		}
 
 		// compute the final contribution
-		moment_feedback_related_force = _sigma_moment * (moment_feedback_term - _kv_moment * _current_angular_velocity);
-	}
-	else  // open loop moment control
+		moment_feedback_related_force =
+			sigma_moment *
+			(moment_feedback_term - _kv_moment * _current_angular_velocity);
+	} else	// open loop moment control
 	{
-		moment_feedback_related_force = _sigma_moment * (- _kv_moment * _current_angular_velocity);
+		moment_feedback_related_force =
+			sigma_moment * (-_kv_moment * _current_angular_velocity);
 	}
 
 	// motion related terms
 	// compute next state from trajectory generation
 #ifdef USING_OTG
-	if(_use_interpolation_flag)
-	{
-		_otg->setGoalPositionAndLinearVelocity(_desired_position, _desired_velocity);
-		_otg->setGoalOrientationAndAngularVelocity(_desired_orientation, _current_orientation, _desired_angular_velocity);
-		_otg->computeNextState(_step_desired_position, _step_desired_velocity, _step_desired_acceleration,
-							_step_desired_orientation, _step_desired_angular_velocity, _step_desired_angular_acceleration);
-		Sai2Model::orientationError(_step_orientation_error, _step_desired_orientation, _current_orientation);
+	if (_use_interpolation_flag) {
+		_otg->setGoalPositionAndLinearVelocity(_desired_position,
+											   _desired_velocity);
+		_otg->setGoalOrientationAndAngularVelocity(_desired_orientation,
+												   _current_orientation,
+												   _desired_angular_velocity);
+		_otg->computeNextState(
+			_step_desired_position, _step_desired_velocity,
+			_step_desired_acceleration, _step_desired_orientation,
+			_step_desired_angular_velocity, _step_desired_angular_acceleration);
+		Sai2Model::orientationError(_step_orientation_error,
+									_step_desired_orientation,
+									_current_orientation);
 	}
 #endif
-	
+
 	// linear motion
 	// update integrated error for I term
-	_integrated_position_error += (_current_position - _step_desired_position) * _loop_timestep;
+	_integrated_position_error +=
+		(_current_position - _step_desired_position) * _loop_timestep;
 
 	// final contribution
-	if(_use_velocity_saturation_flag)
-	{
-		_step_desired_velocity = -_kp_pos_mat * _kv_pos_mat.inverse() * (_current_position - _step_desired_position) - _ki_pos_mat * _kv_pos_mat.inverse() * _integrated_position_error;
-		if(_step_desired_velocity.norm() > _linear_saturation_velocity)
-		{
-			_step_desired_velocity *= _linear_saturation_velocity/_step_desired_velocity.norm();
+	if (_use_velocity_saturation_flag) {
+		_step_desired_velocity =
+			-_kp_pos * _kv_pos.inverse() *
+				(_current_position - _step_desired_position) -
+			_ki_pos * _kv_pos.inverse() * _integrated_position_error;
+		if (_step_desired_velocity.norm() > _linear_saturation_velocity) {
+			_step_desired_velocity *=
+				_linear_saturation_velocity / _step_desired_velocity.norm();
 		}
-		position_related_force = _sigma_position * (_step_desired_acceleration -_kv_pos_mat*(_current_velocity - _step_desired_velocity));
+		position_related_force =
+			sigma_position *
+			(_step_desired_acceleration -
+			 _kv_pos * (_current_velocity - _step_desired_velocity));
+	} else {
+		position_related_force =
+			sigma_position *
+			(_step_desired_acceleration -
+			 _kp_pos * (_current_position - _step_desired_position) -
+			 _kv_pos * (_current_velocity - _step_desired_velocity) -
+			 _ki_pos * _integrated_position_error);
 	}
-	else
-	{
-		position_related_force = _sigma_position*( _step_desired_acceleration - _kp_pos_mat*(_current_position - _step_desired_position) - _kv_pos_mat*(_current_velocity - _step_desired_velocity ) - _ki_pos_mat * _integrated_position_error);
-	}
-
 
 	// angular motion
 	// update integrated error for I term
 	_integrated_orientation_error += _step_orientation_error * _loop_timestep;
 
 	// final contribution
-	if(_use_velocity_saturation_flag)
-	{
-		_step_desired_angular_velocity = -_kp_ori_mat * _kv_ori_mat.inverse() * _step_orientation_error - _ki_ori_mat * _kv_ori_mat.inverse() * _integrated_orientation_error;
-		if(_step_desired_angular_velocity.norm() > _angular_saturation_velocity)
-		{
-			_step_desired_angular_velocity *= _angular_saturation_velocity/_step_desired_angular_velocity.norm();
+	if (_use_velocity_saturation_flag) {
+		_step_desired_angular_velocity =
+			-_kp_ori * _kv_ori.inverse() * _step_orientation_error -
+			_ki_ori * _kv_ori.inverse() * _integrated_orientation_error;
+		if (_step_desired_angular_velocity.norm() >
+			_angular_saturation_velocity) {
+			_step_desired_angular_velocity *=
+				_angular_saturation_velocity /
+				_step_desired_angular_velocity.norm();
 		}
-		orientation_related_force = _sigma_orientation * (_step_desired_angular_acceleration - _kv_ori_mat*(_current_angular_velocity - _step_desired_angular_velocity));
-	}
-	else
-	{
-		orientation_related_force = _sigma_orientation * (_step_desired_angular_acceleration - _kp_ori_mat*_step_orientation_error - _kv_ori_mat*(_current_angular_velocity - _step_desired_angular_velocity) - _ki_ori_mat*_integrated_orientation_error);
+		orientation_related_force =
+			sigma_orientation * (_step_desired_angular_acceleration -
+								 _kv_ori * (_current_angular_velocity -
+											_step_desired_angular_velocity));
+	} else {
+		orientation_related_force =
+			sigma_orientation * (_step_desired_angular_acceleration -
+								 _kp_ori * _step_orientation_error -
+								 _kv_ori * (_current_angular_velocity -
+											_step_desired_angular_velocity) -
+								 _ki_ori * _integrated_orientation_error);
 	}
 
 	// compute task force
@@ -397,21 +390,25 @@ VectorXd MotionForceTask::computeTorques()
 	_unit_mass_force = position_orientation_contribution;
 
 	VectorXd feedforward_force_moment = VectorXd::Zero(6);
-	feedforward_force_moment.head(3) = _sigma_force * _desired_force;
-	feedforward_force_moment.tail(3) = _sigma_moment * _desired_moment;
+	feedforward_force_moment.head(3) = sigma_force * _desired_force;
+	feedforward_force_moment.tail(3) = sigma_moment * _desired_moment;
 
-	if(_closed_loop_force_control)
-	{
+	if (_closed_loop_force_control) {
 		feedforward_force_moment *= _k_ff;
 	}
 
-	_linear_force_control = force_feedback_related_force + feedforward_force_moment.head(3);
+	_linear_force_control =
+		force_feedback_related_force + feedforward_force_moment.head(3);
 	_linear_motion_control = position_related_force;
 
-	_task_force = _Lambda_modified * _URange.transpose() * (position_orientation_contribution) + _URange.transpose() * (force_moment_contribution + feedforward_force_moment);
+	_task_force = _Lambda_modified * _URange.transpose() *
+					  (position_orientation_contribution) +
+				  _URange.transpose() *
+					  (force_moment_contribution + feedforward_force_moment);
 
 	// compute task torques
-	task_joint_torques = _projected_jacobian.transpose() * _URange * _task_force;
+	task_joint_torques =
+		_projected_jacobian.transpose() * _URange * _task_force;
 
 	// update previous time
 	_prev_projected_jacobian = _projected_jacobian;
@@ -419,14 +416,18 @@ VectorXd MotionForceTask::computeTorques()
 	return task_joint_torques;
 }
 
-bool MotionForceTask::goalPositionReached(const double tolerance, const bool verbose)
-{
-	double position_error = (_desired_position - _current_position).transpose() * ( _URange_pos * _sigma_position * _URange_pos.transpose()) * (_desired_position - _current_position);
+bool MotionForceTask::goalPositionReached(const double tolerance,
+										  const bool verbose) {
+	Matrix3d sigma_position = Matrix3d::Identity() - sigmaForce();
+	double position_error =
+		(_desired_position - _current_position).transpose() *
+		(_URange_pos * sigma_position * _URange_pos.transpose()) *
+		(_desired_position - _current_position);
 	position_error = sqrt(position_error);
 	bool goal_reached = position_error < tolerance;
-	if(verbose)
-	{
-		cout << "position error in MotionForceTask : " << position_error << endl;
+	if (verbose) {
+		cout << "position error in MotionForceTask : " << position_error
+			 << endl;
 		cout << "Tolerance : " << tolerance << endl;
 		cout << "Goal reached : " << goal_reached << endl << endl;
 	}
@@ -434,14 +435,17 @@ bool MotionForceTask::goalPositionReached(const double tolerance, const bool ver
 	return goal_reached;
 }
 
-bool MotionForceTask::goalOrientationReached(const double tolerance, const bool verbose)
-{
-	double orientation_error = _orientation_error.transpose() * _URange_ori * _sigma_orientation * _URange_ori.transpose() * _orientation_error;
+bool MotionForceTask::goalOrientationReached(const double tolerance,
+											 const bool verbose) {
+	Matrix3d sigma_orientation = Matrix3d::Identity() - sigmaMoment();
+	double orientation_error = _orientation_error.transpose() * _URange_ori *
+							   sigma_orientation * _URange_ori.transpose() *
+							   _orientation_error;
 	orientation_error = sqrt(orientation_error);
 	bool goal_reached = orientation_error < tolerance;
-	if(verbose)
-	{
-		cout << "orientation error in MotionForceTask : " << orientation_error << endl;
+	if (verbose) {
+		cout << "orientation error in MotionForceTask : " << orientation_error
+			 << endl;
 		cout << "Tolerance : " << tolerance << endl;
 		cout << "Goal reached : " << goal_reached << endl << endl;
 	}
@@ -449,290 +453,236 @@ bool MotionForceTask::goalOrientationReached(const double tolerance, const bool 
 	return goal_reached;
 }
 
-void MotionForceTask::setDynamicDecouplingFull()
-{
-	_dynamic_decoupling_type = FULL_DYNAMIC_DECOUPLING;
+void MotionForceTask::setPosControlGains(double kp_pos, double kv_pos,
+										 double ki_pos) {
+	_are_pos_gains_isotropic = true;
+	_kp_pos = kp_pos * Matrix3d::Identity();
+	_kv_pos = kv_pos * Matrix3d::Identity();
+	_ki_pos = ki_pos * Matrix3d::Identity();
 }
 
-void MotionForceTask::setDynamicDecouplingPartial()
-{
-	_dynamic_decoupling_type = PARTIAL_DYNAMIC_DECOUPLING;
+void MotionForceTask::setPosControlGains(const Vector3d& kp_pos,
+										 const Vector3d& kv_pos,
+										 const Vector3d& ki_pos) {
+	_are_pos_gains_isotropic = false;
+	Matrix3d rotation = _is_force_motion_parametrization_in_compliant_frame
+							? _compliant_frame.rotation()
+							: Matrix3d::Identity();
+	_kp_pos = rotation * kp_pos.asDiagonal() * rotation.transpose();
+	_kv_pos = rotation * kv_pos.asDiagonal() * rotation.transpose();
+	_ki_pos = rotation * ki_pos.asDiagonal() * rotation.transpose();
 }
 
-void MotionForceTask::setDynamicDecouplingNone()
-{
-	_dynamic_decoupling_type = IMPEDANCE;
-}
-
-void MotionForceTask::setDynamicDecouplingBIE()
-{
-	_dynamic_decoupling_type = BOUNDED_INERTIA_ESTIMATES;
-}
-
-void MotionForceTask::setNonIsotropicGainsPosition(const Matrix3d& frame, const Vector3d& kp, 
-	const Vector3d& kv, const Vector3d& ki)
-{
-	if( (Matrix3d::Identity() - frame.transpose()*frame).norm() > 1e-3 || frame.determinant() < 0)
-	{
-		throw invalid_argument("not a valid right hand frame in MotionForceTask::setNonIsotropicGainsPosition\n");
+vector<PIDGains> MotionForceTask::getPosControlGains() const {
+	if (_are_pos_gains_isotropic) {
+		return vector<PIDGains>(
+			1, PIDGains(_kp_pos(0, 0), _kv_pos(0, 0), _ki_pos(0, 0)));
 	}
+	Matrix3d rotation = _is_force_motion_parametrization_in_compliant_frame
+							? _compliant_frame.rotation()
+							: Matrix3d::Identity();
+	Vector3d aniso_kp_robot_base =
+		(rotation.transpose() * _kp_pos * rotation).diagonal();
+	Vector3d aniso_kv_robot_base =
+		(rotation.transpose() * _kv_pos * rotation).diagonal();
+	Vector3d aniso_ki_robot_base =
+		(rotation.transpose() * _ki_pos * rotation).diagonal();
+	return vector<PIDGains>{
+		PIDGains(aniso_kp_robot_base(0), aniso_kv_robot_base(0),
+				 aniso_ki_robot_base(0)),
+		PIDGains(aniso_kp_robot_base(1), aniso_kv_robot_base(1),
+				 aniso_ki_robot_base(1)),
+		PIDGains(aniso_kp_robot_base(2), aniso_kv_robot_base(2),
+				 aniso_ki_robot_base(2))};
+}
 
-	_use_isotropic_gains_position = false;
+void MotionForceTask::setOriControlGains(double kp_ori, double kv_ori,
+										 double ki_ori) {
+	_are_ori_gains_isotropic = true;
+	_kp_ori = kp_ori * Matrix3d::Identity();
+	_kv_ori = kv_ori * Matrix3d::Identity();
+	_ki_ori = ki_ori * Matrix3d::Identity();
+}
 
-	Matrix3d kp_pos_mat_tmp = Matrix3d::Zero();
-	Matrix3d kv_pos_mat_tmp = Matrix3d::Zero();
-	Matrix3d ki_pos_mat_tmp = Matrix3d::Zero();
+void MotionForceTask::setOriControlGains(const Vector3d& kp_ori,
+										 const Vector3d& kv_ori,
+										 const Vector3d& ki_ori) {
+	_are_ori_gains_isotropic = false;
+	Matrix3d rotation = _is_force_motion_parametrization_in_compliant_frame
+							? _compliant_frame.rotation()
+							: Matrix3d::Identity();
+	_kp_ori = rotation * kp_ori.asDiagonal() * rotation.transpose();
+	_kv_ori = rotation * kv_ori.asDiagonal() * rotation.transpose();
+	_ki_ori = rotation * ki_ori.asDiagonal() * rotation.transpose();
+}
 
-	for(int i=0 ; i<3 ; i++)
-	{
-		kp_pos_mat_tmp(i,i) = kp(i);
-		kv_pos_mat_tmp(i,i) = kv(i);
-		ki_pos_mat_tmp(i,i) = ki(i);
+vector<PIDGains> MotionForceTask::getOriControlGains() const {
+	if (_are_ori_gains_isotropic) {
+		return vector<PIDGains>(
+			1, PIDGains(_kp_ori(0, 0), _kv_ori(0, 0), _ki_ori(0, 0)));
 	}
-
-	_kp_pos_mat = frame * kp_pos_mat_tmp * frame.transpose();
-	_kv_pos_mat = frame * kv_pos_mat_tmp * frame.transpose();
-	_ki_pos_mat = frame * ki_pos_mat_tmp * frame.transpose();
-
+	Matrix3d rotation = _is_force_motion_parametrization_in_compliant_frame
+							? _compliant_frame.rotation()
+							: Matrix3d::Identity();
+	Vector3d aniso_kp_robot_base =
+		(rotation.transpose() * _kp_ori * rotation).diagonal();
+	Vector3d aniso_kv_robot_base =
+		(rotation.transpose() * _kv_ori * rotation).diagonal();
+	Vector3d aniso_ki_robot_base =
+		(rotation.transpose() * _ki_ori * rotation).diagonal();
+	return vector<PIDGains>{
+		PIDGains(aniso_kp_robot_base(0), aniso_kv_robot_base(0),
+				 aniso_ki_robot_base(0)),
+		PIDGains(aniso_kp_robot_base(1), aniso_kv_robot_base(1),
+				 aniso_ki_robot_base(1)),
+		PIDGains(aniso_kp_robot_base(2), aniso_kv_robot_base(2),
+				 aniso_ki_robot_base(2))};
 }
 
-void MotionForceTask::setNonIsotropicGainsOrientation(const Matrix3d& frame, const Vector3d& kp, 
-	const Vector3d& kv, const Vector3d& ki)
-{
-	if( (Matrix3d::Identity() - frame.transpose()*frame).norm() > 1e-3 || frame.determinant() < 0)
-	{
-		throw invalid_argument("not a valid right hand frame in MotionForceTask::setNonIsotropicGainsOrientation\n");
+void MotionForceTask::setForceSensorFrame(
+	const string link_name, const Affine3d transformation_in_link) {
+	if (link_name != _link_name) {
+		throw invalid_argument(
+			"The link to which is attached the sensor should be the same as "
+			"the link to which is attached the control frame in "
+			"MotionForceTask::setForceSensorFrame\n");
 	}
-
-	_use_isotropic_gains_orientation = false;
-
-	Matrix3d kp_ori_mat_tmp = Matrix3d::Zero();
-	Matrix3d kv_ori_mat_tmp = Matrix3d::Zero();
-	Matrix3d ki_ori_mat_tmp = Matrix3d::Zero();
-
-	for(int i=0 ; i<3 ; i++)
-	{
-		kp_ori_mat_tmp(i,i) = kp(i);
-		kv_ori_mat_tmp(i,i) = kv(i);
-		ki_ori_mat_tmp(i,i) = ki(i);
-	}
-
-	_kp_ori_mat = frame * kp_ori_mat_tmp * frame.transpose();
-	_kv_ori_mat = frame * kv_ori_mat_tmp * frame.transpose();
-	_ki_ori_mat = frame * ki_ori_mat_tmp * frame.transpose();	
+	_T_control_to_sensor = _compliant_frame.inverse() * transformation_in_link;
 }
 
-void MotionForceTask::setIsotropicGainsPosition(const double kp, const double kv, const double ki)
-{
-	_use_isotropic_gains_position = true;
-
-	_kp_pos = kp;
-	_kv_pos = kv;
-	_ki_pos = ki;
-}
-
-void MotionForceTask::setIsotropicGainsOrientation(const double kp, const double kv, const double ki)
-{
-	_use_isotropic_gains_orientation = true;
-
-	_kp_ori = kp;
-	_kv_ori = kv;
-	_ki_ori = ki;	
-}
-
-void MotionForceTask::setForceSensorFrame(const string link_name, const Affine3d transformation_in_link)
-{
-	if(link_name != _link_name)
-	{
-		throw invalid_argument("The link to which is attached the sensor should be the same as the link to which is attached the control frame in MotionForceTask::setForceSensorFrame\n");
-	}
-	_T_control_to_sensor = _control_frame.inverse() * transformation_in_link;
-}
-
-void MotionForceTask::updateSensedForceAndMoment(const Vector3d sensed_force_sensor_frame, 
-							    		    const Vector3d sensed_moment_sensor_frame)
-{
+void MotionForceTask::updateSensedForceAndMoment(
+	const Vector3d sensed_force_sensor_frame,
+	const Vector3d sensed_moment_sensor_frame) {
 	// find the transform from base frame to control frame
 	Affine3d T_base_link = _robot->transform(_link_name);
-	Affine3d T_base_control = T_base_link * _control_frame;
+	Affine3d T_base_control = T_base_link * _compliant_frame;
 
 	// find the resolved sensed force and moment in control frame
 	_sensed_force = _T_control_to_sensor.rotation() * sensed_force_sensor_frame;
-	_sensed_moment = _T_control_to_sensor.translation().cross(_sensed_force) + _T_control_to_sensor.rotation() * sensed_moment_sensor_frame;
+	_sensed_moment =
+		_T_control_to_sensor.translation().cross(_sensed_force) +
+		_T_control_to_sensor.rotation() * sensed_moment_sensor_frame;
 
 	// rotate the quantities in base frame
 	_sensed_force = T_base_control.rotation() * _sensed_force;
 	_sensed_moment = T_base_control.rotation() * _sensed_moment;
 }
 
-void MotionForceTask::setForceAxis(const Vector3d force_axis)
-{
-	Vector3d normalized_axis = force_axis.normalized();
-
-	_sigma_force = normalized_axis*normalized_axis.transpose();
-	_sigma_position = Matrix3d::Identity() - _sigma_force;
-
-	resetIntegratorsLinear();
-#ifdef USING_OTG 
-	_otg->reInitialize(_current_position, _current_orientation);
-#endif
-}
-
-void MotionForceTask::updateForceAxis(const Vector3d force_axis)
-{
-	Vector3d normalized_axis = force_axis.normalized();
-
-	_sigma_force = normalized_axis*normalized_axis.transpose();
-	_sigma_position = Matrix3d::Identity() - _sigma_force;
-}
-
-void MotionForceTask::setLinearMotionAxis(const Vector3d motion_axis)
-{
-	Vector3d normalized_axis = motion_axis.normalized();
-
-	_sigma_position = normalized_axis*normalized_axis.transpose();
-	_sigma_force = Matrix3d::Identity() - _sigma_position;
-
-	resetIntegratorsLinear();
-#ifdef USING_OTG 
-	_otg->reInitialize(_current_position, _current_orientation);
-#endif
-}
-
-void MotionForceTask::updateLinearMotionAxis(const Vector3d motion_axis)
-{
-	Vector3d normalized_axis = motion_axis.normalized();
-
-	_sigma_position = normalized_axis*normalized_axis.transpose();
-	_sigma_force = Matrix3d::Identity() - _sigma_position;	
-}
-
-void MotionForceTask::setFullForceControl()
-{
-	_sigma_force = Matrix3d::Identity();
-	_sigma_position.setZero();
-
-	resetIntegratorsLinear();
-#ifdef USING_OTG 
-	_otg->reInitialize(_current_position, _current_orientation);
-#endif
-}
-
-void MotionForceTask::setFullLinearMotionControl()
-{
-	_sigma_position = Matrix3d::Identity();
-	_sigma_force.setZero();
-
-	resetIntegratorsLinear();
-#ifdef USING_OTG 
-	_otg->reInitialize(_current_position, _current_orientation);
-#endif
-}
-
-void MotionForceTask::setMomentAxis(const Vector3d moment_axis)
-{
-	Vector3d normalized_axis = moment_axis.normalized();
-
-	_sigma_moment = normalized_axis*normalized_axis.transpose();
-	_sigma_orientation = Matrix3d::Identity() - _sigma_moment;
-
-	resetIntegratorsAngular();
-}
-
-void MotionForceTask::updateMomentAxis(const Vector3d moment_axis)
-{
-	Vector3d normalized_axis = moment_axis.normalized();
-
-	_sigma_moment = normalized_axis*normalized_axis.transpose();
-	_sigma_orientation = Matrix3d::Identity() - _sigma_moment;	
-}
-
-void MotionForceTask::setAngularMotionAxis(const Vector3d motion_axis)
-{
-	Vector3d normalized_axis = motion_axis.normalized();
-
-	_sigma_orientation = normalized_axis*normalized_axis.transpose();
-	_sigma_moment = Matrix3d::Identity() - _sigma_orientation;
-
-	resetIntegratorsAngular();
-}
-
-void MotionForceTask::updateAngularMotionAxis(const Vector3d motion_axis)
-{
-	Vector3d normalized_axis = motion_axis.normalized();
-
-	_sigma_orientation = normalized_axis*normalized_axis.transpose();
-	_sigma_moment = Matrix3d::Identity() - _sigma_orientation;
-}
-
-void MotionForceTask::setFullMomentControl()
-{
-	_sigma_moment = Matrix3d::Identity();
-	_sigma_orientation.setZero();
-
-	resetIntegratorsAngular();
-}
-
-void MotionForceTask::setFullAngularMotionControl()
-{
-	_sigma_orientation = Matrix3d::Identity();
-	_sigma_moment.setZero();
-
-	resetIntegratorsAngular();
-}
-
-void MotionForceTask::setClosedLoopForceControl()
-{
-	_closed_loop_force_control = true;
+void MotionForceTask::parametrizeForceMotionSpaces(
+	const int force_space_dimension,
+	const Vector3d& force_or_motion_single_axis) {
+	if (force_space_dimension < 0 || force_space_dimension > 3) {
+		throw invalid_argument(
+			"Force space dimension should be between 0 and 3 in "
+			"MotionForceTask::parametrizeForceMotionSpaces\n");
+	}
+	_force_space_dimension = force_space_dimension;
+	if (force_space_dimension == 1 || force_space_dimension == 2) {
+		if (force_or_motion_single_axis.norm() < 1e-2) {
+			throw invalid_argument(
+				"Force or motion axis should be a non singular vector in "
+				"MotionForceTask::parametrizeForceMotionSpaces\n");
+		}
+		_force_or_motion_axis = force_or_motion_single_axis.normalized();
+	}
 	resetIntegratorsLinear();
 }
 
-void MotionForceTask::setOpenLoopForceControl()
-{
-	_closed_loop_force_control = false;
-}
-
-void MotionForceTask::setClosedLoopMomentControl()
-{
-	_closed_loop_moment_control = true;
+void MotionForceTask::parametrizeMomentRotMotionSpaces(
+	const int moment_space_dimension,
+	const Vector3d& moment_or_rot_motion_single_axis) {
+	if (moment_space_dimension < 0 || moment_space_dimension > 3) {
+		throw invalid_argument(
+			"Moment space dimension should be between 0 and 3 in "
+			"MotionForceTask::parametrizeMomentRotMotionSpaces\n");
+	}
+	_moment_space_dimension = moment_space_dimension;
+	if (moment_space_dimension == 1 || moment_space_dimension == 2) {
+		if (moment_or_rot_motion_single_axis.norm() < 1e-2) {
+			throw invalid_argument(
+				"Moment or rot motion axis should be a non singular vector in "
+				"MotionForceTask::parametrizeMomentRotMotionSpaces\n");
+		}
+		_moment_or_rotmotion_axis =
+			moment_or_rot_motion_single_axis.normalized();
+	}
 	resetIntegratorsAngular();
 }
 
-void MotionForceTask::setOpenLoopMomentControl()
-{
-	_closed_loop_moment_control = false;
+Matrix3d MotionForceTask::sigmaForce() const {
+	Matrix3d rotation = _is_force_motion_parametrization_in_compliant_frame
+							? _compliant_frame.rotation()
+							: Matrix3d::Identity();
+	switch (_force_space_dimension) {
+		case 0:
+			return Matrix3d::Zero();
+			break;
+		case 1:
+			return rotation * _force_or_motion_axis *
+				   _force_or_motion_axis.transpose() * rotation.transpose();
+			break;
+		case 2:
+			return Matrix3d::Identity() -
+				   rotation * _force_or_motion_axis *
+					   _force_or_motion_axis.transpose() * rotation.transpose();
+			break;
+		case 3:
+			return Matrix3d::Identity();
+			break;
+
+		default:
+			// should never happen
+			throw invalid_argument(
+				"Force space dimension should be between 0 and 3 in "
+				"MotionForceTask::sigmaForce\n");
+			break;
+	}
 }
 
-void MotionForceTask::enablePassivity()
-{
-	_POPC_force->enable();
+Matrix3d MotionForceTask::sigmaMoment() const {
+	Matrix3d rotation = _is_force_motion_parametrization_in_compliant_frame
+							? _compliant_frame.rotation()
+							: Matrix3d::Identity();
+	switch (_moment_space_dimension) {
+		case 0:
+			return Matrix3d::Zero();
+			break;
+		case 1:
+			return rotation * _moment_or_rotmotion_axis *
+				   _moment_or_rotmotion_axis.transpose() * rotation.transpose();
+			break;
+		case 2:
+			return Matrix3d::Identity() -
+				   rotation * _moment_or_rotmotion_axis *
+					   _moment_or_rotmotion_axis.transpose() *
+					   rotation.transpose();
+			break;
+		case 3:
+			return Matrix3d::Identity();
+			break;
+
+		default:
+			// should never happen
+			throw invalid_argument(
+				"Moment space dimension should be between 0 and 3 in "
+				"MotionForceTask::sigmaMoment\n");
+			break;
+	}
 }
 
-void MotionForceTask::disablePassivity()
-{
-	_POPC_force->disable();
+void MotionForceTask::resetIntegrators() {
+	resetIntegratorsLinear();
+	resetIntegratorsAngular();
 }
 
-void MotionForceTask::resetIntegrators()
-{
-	_integrated_orientation_error.setZero();
-	_integrated_position_error.setZero();
-	_integrated_force_error.setZero();
-	_integrated_moment_error.setZero();
-}
-
-void MotionForceTask::resetIntegratorsLinear()
-{
+void MotionForceTask::resetIntegratorsLinear() {
 	_integrated_position_error.setZero();
 	_integrated_force_error.setZero();
 }
 
-void MotionForceTask::resetIntegratorsAngular()
-{
+void MotionForceTask::resetIntegratorsAngular() {
 	_integrated_orientation_error.setZero();
 	_integrated_moment_error.setZero();
 }
-
 
 } /* namespace Sai2Primitives */
-

--- a/src/tasks/MotionForceTask.h
+++ b/src/tasks/MotionForceTask.h
@@ -15,6 +15,7 @@
 
 #include "Sai2Model.h"
 #include <helper_modules/POPCExplicitForceControl.h>
+#include <helper_modules/Sai2PrimitivesCommonDefinitions.h>
 #include <Eigen/Dense>
 #include <string>
 // #include <chrono>
@@ -31,14 +32,6 @@ using namespace std;
 namespace Sai2Primitives
 {
 
-struct PIDGains {
-	double kp;
-	double kv;
-	double ki;
-
-	PIDGains(double kp, double kv, double ki) : kp(kp), kv(kv), ki(ki) {}
-};
-
 class MotionForceTask
 {
 
@@ -53,62 +46,70 @@ enum DynamicDecouplingType
 public:
 
 	//------------------------------------------------
-	// Constructors
+	// Constructor
 	//------------------------------------------------
 
 	/**
-	 * @brief      Constructor that takes an Affine3d matrix for definition of
-	 *             the control frame. Creates a full position controller by
-	 *             default.
+	 * @brief Construct a new Motion Force Task
 	 *
-	 * @param      robot          A pointer to a Sai2Model object for the robot
-	 *                            that is to be controlled
-	 * @param      link_name      The name of the link in the robot at which to
-	 *                            attach the control frame
-	 * @param      control_frame  The position and orientation of the control
-	 *                            frame in local link coordinates
-	 * @param[in]  loop_timestep      time taken by a control loop. Used in
-	 *                            trajectory generation and integral control
+	 * @param robot A pointer to a Sai2Model object for the robot that is to be
+	 * controlled
+	 * @param link_name The name of the link in the robot at which to attach the
+	 * compliant frame
+	 * @param compliant_frame Compliant frame with respect to link frame
+	 * @param is_force_motion_parametrization_in_compliant_frame Whether the
+	 * force and motion space (and potential non isotropic gains) are defined
+	 * with respect to the compliant frome or the robot base frame
+	 * @param loop_timestep Time taken by a control loop. Used in trajectory
+	 * generation and integral control.
 	 */
-	MotionForceTask(Sai2Model::Sai2Model* robot, 
-		            const string link_name, 
-		            const Affine3d control_frame = Affine3d::Identity(),
-		            const double loop_timestep = 0.001);
-
-	/**
-	 * @brief      Constructor that takes a Vector3d for definition of the
-	 *             control frame position and a Matrix3d for the frame
-	 *             orientation. Creates a full position controller by default.
-	 *
-	 * @param      robot        A pointer to a Sai2Model object for the robot
-	 *                          that is to be controlled
-	 * @param      link_name    The name of the link in the robot at which to
-	 *                          attach the control frame
-	 * @param      pos_in_link  The position the control frame in local link
-	 *                          coordinates
-	 * @param      rot_in_link  The orientation of the control frame in local
-	 *                          link coordinates
-	 * @param[in]  loop_timestep    time taken by a control loop. Used in
-	 *                          trajectory generation and integral control
-	 */
-	MotionForceTask(Sai2Model::Sai2Model* robot, 
-		            const string link_name, 
-		            const Vector3d pos_in_link, 
-		            const Matrix3d rot_in_link = Matrix3d::Identity(),
-		            const double loop_timestep = 0.001);
+	MotionForceTask(std::shared_ptr<Sai2Model::Sai2Model> robot, const string& link_name,
+					const Affine3d& compliant_frame = Affine3d::Identity(),
+					const bool is_force_motion_parametrization_in_compliant_frame = false,
+					const double loop_timestep = 0.001);
 
 	//------------------------------------------------
 	// Getters Setters
 	//------------------------------------------------
 
+	/**
+	 * @brief Get the Current Position
+	 * 
+	 * @return const Vector3d& current position of the control point
+	 */
 	const Vector3d& getCurrentPosition() const { return _current_position; }
+	/**
+	 * @brief Get the Current Velocity
+	 * 
+	 * @return const Vector3d& current velocity of the control point
+	 */
 	const Vector3d& getCurrentVelocity() const { return _current_velocity; }
 
+	/**
+	 * @brief Get the Current Orientation
+	 * 
+	 * @return const Matrix3d& current orientation of the control frame
+	 */
 	const Matrix3d& getCurrentOrientation() const { return _current_orientation; }
+	/**
+	 * @brief Get the Current Angular Velocity
+	 * 
+	 * @return const Vector3d& current angular velocity of the control frame
+	 */
 	const Vector3d& getCurrentAngularVelocity() const { return _current_angular_velocity; }
 
+	/**
+	 * @brief Get the Sensed Force resolved at the control frame
+	 * 
+	 * @return const Vector3d& current sensed force in the control frame
+	 */
 	const Vector3d& getSensedForce() const {return _sensed_force;}
 
+	/**
+	 * @brief Get the nullspace matrix of that task and the previous ones in the hierarchy
+	 * 
+	 * @return const MatrixXd& Nulspace matrix of the task and the previous ones
+	 */
 	const MatrixXd& getN() const {return _N;}
 
 	void setDesiredPosition(const Vector3d& desired_position) {
@@ -149,38 +150,31 @@ public:
 	void setPosControlGains(const PIDGains& gains) {
 		setPosControlGains(gains.kp, gains.kv, gains.ki);
 	}
-	void setPosControlGains(double kp_pos, double kv_pos, double ki_pos = 0) {
-		_kp_pos = kp_pos;
-		_kv_pos = kv_pos;
-		_ki_pos = ki_pos;
-	}
-	PIDGains getPosControlGains() const {
-		return PIDGains(_kp_pos, _kv_pos, _ki_pos);
-	}
+	void setPosControlGains(double kp_pos, double kv_pos, double ki_pos = 0);
+	void setPosControlGains(const Vector3d& kp_pos, const Vector3d& kv_pos,
+							const Vector3d& ki_pos = Vector3d::Zero());
+	vector<PIDGains> getPosControlGains() const;
 
 	void setOriControlGains(const PIDGains& gains) {
 		setOriControlGains(gains.kp, gains.kv, gains.ki);
 	}
-	void setOriControlGains(double kp_ori, double kv_ori, double ki_ori = 0) {
-		_kp_ori = kp_ori;
-		_kv_ori = kv_ori;
-		_ki_ori = ki_ori;
-	}
-	PIDGains getOriControlGains() const {
-		return PIDGains(_kp_ori, _kv_ori, _ki_ori);
-	}
+	void setOriControlGains(double kp_ori, double kv_ori, double ki_ori = 0);
+	void setOriControlGains(const Vector3d& kp_ori, const Vector3d& kv_ori,
+							const Vector3d& ki_ori = Vector3d::Zero());
+	vector<PIDGains> getOriControlGains() const;
 
 	void setForceControlGains(const PIDGains& gains) {
 		setForceControlGains(gains.kp, gains.kv, gains.ki);
 	}
 	void setForceControlGains(double kp_force, double kv_force,
 							  double ki_force) {
-		_kp_force = kp_force;
-		_kv_force = kv_force;
-		_ki_force = ki_force;
+		_kp_force = kp_force * Matrix3d::Identity();
+		_kv_force = kv_force * Matrix3d::Identity();
+		_ki_force = ki_force * Matrix3d::Identity();
 	}
-	PIDGains getForceControlGains() const {
-		return PIDGains(_kp_force, _kv_force, _ki_force);
+	vector<PIDGains> getForceControlGains() const {
+		return vector<PIDGains>(1, PIDGains(_kp_force(0, 0), _kv_force(0, 0),
+								_ki_force(0, 0)));
 	}
 
 	void setMomentControlGains(const PIDGains& gains) {
@@ -188,22 +182,43 @@ public:
 	}
 	void setMomentControlGains(double kp_moment, double kv_moment,
 							   double ki_moment) {
-		_kp_moment = kp_moment;
-		_kv_moment = kv_moment;
-		_ki_moment = ki_moment;
+		_kp_moment = kp_moment * Matrix3d::Identity();
+		_kv_moment = kv_moment * Matrix3d::Identity();
+		_ki_moment = ki_moment * Matrix3d::Identity();
 	}
-	PIDGains getMomentControlGains() const {
-		return PIDGains(_kp_moment, _kv_moment, _ki_moment);
+	vector<PIDGains> getMomentControlGains() const {
+		return vector<PIDGains>(1, PIDGains(_kp_moment(0, 0), _kv_moment(0, 0),
+								_ki_moment(0, 0)));
 	}
 
+	/**
+	 * @brief Set the Desired Force in control frame
+	 * 
+	 * @param desired_force 
+	 */
 	void setDesiredForce(const Vector3d& desired_force) {
 		_desired_force = desired_force;
 	}
+	/**
+	 * @brief Get the Desired Force in control frame
+	 * 
+	 * @return const Vector3d& desired force in control frame
+	 */
 	const Vector3d& getDesiredForce() const { return _desired_force; }
 
+	/**
+	 * @brief Set the Desired Moment in control frame
+	 * 
+	 * @param desired_moment 
+	 */
 	void setDesiredMoment(const Vector3d& desired_moment) {
 		_desired_moment = desired_moment;
 	}
+	/**
+	 * @brief Get the Desired Moment in control frame
+	 * 
+	 * @return const Vector3d& desired moment in control frame
+	 */
 	const Vector3d& getDesiredMoment() const { return _desired_moment; }
 
 	// Velocity saturation flag and saturation values
@@ -261,8 +276,6 @@ public:
 	 *             positions/velocities assumes the desired orientation and
 	 *             angular velocity has been updated
 	 *
-	 * @param      task_joint_torques  the vector to be filled with the new
-	 *                                 joint torques to apply for the task
 	 */
 	VectorXd computeTorques();
 
@@ -292,20 +305,13 @@ public:
 	 */
 	bool goalOrientationReached(const double tolerance, const bool verbose = false);
 
-
 	// ---------- set dynamic decoupling type for the controller  ----------------
-	void setDynamicDecouplingFull();
-	void setDynamicDecouplingPartial();
-	void setDynamicDecouplingNone();
-	void setDynamicDecouplingBIE();
-
-	void setNonIsotropicGainsPosition(const Matrix3d& frame, const Vector3d& kp, 
-		const Vector3d& kv, const Vector3d& ki);
-	void setNonIsotropicGainsOrientation(const Matrix3d& frame, const Vector3d& kp, 
-		const Vector3d& kv, const Vector3d& ki);
-
-	void setIsotropicGainsPosition(const double kp, const double kv, const double ki);
-	void setIsotropicGainsOrientation(const double kp, const double kv, const double ki);
+	void setDynamicDecouplingType(const DynamicDecouplingType type) {
+		_dynamic_decoupling_type = type;
+	}
+	DynamicDecouplingType getDynamicDecouplingType() const {
+		return _dynamic_decoupling_type;
+	}
 
 	// -------- force control related methods --------
 
@@ -339,188 +345,65 @@ public:
 								    const Vector3d sensed_moment_sensor_frame);
 
 	/**
-	 * @brief      Sets the force controlled axis for a hybrid position force
-	 *             controller with 1 DoF force and 2 DoF motion
-	 * @details    This is the function to use in order to get the position part
-	 *             of the controller behave as a Hybrid Force/Motion controller
-	 *             with 1 Dof force. The motion is controlled orthogonally to
-	 *             the force. It can be called anytime to change the behavior of
-	 *             the controller and reset the integral terms.
+	 * @brief Parametrizes the force space and motion space for translational
+	 * control The first argument is the dimension of the force space (between
+	 * 0 and 3, 0 meaning the whole translation is controlled in motion and 3
+	 * meaning the whole translation is controlled in force) and the second
+	 * argument is the axis defining the space of dimension one (unused if the
+	 * first parameter is 0 or 3, and representing the direction of the force
+	 * space is the first parameter is 1, or the direction of the motion space
+	 * if the first parameter is 2)
 	 *
-	 * @param      force_axis  The axis in robot frame coordinates along which
-	 *                         the controller behaves as a force controller.
+	 * @param force_space_dimension  between 0 and 3
+	 * @param force_or_motion_single_axis non singular axis (unused if
+	 * force_space_dimension is 0 or 3)
 	 */
-	void setForceAxis(const Vector3d force_axis);
+	void parametrizeForceMotionSpaces(
+		const int force_space_dimension,
+		const Vector3d& force_or_motion_single_axis = Vector3d::Zero());
 
 	/**
-	 * @brief      Updates the force controlled axis for a hybrid position force
-	 *             controller with 1 DoF force and 2 DoF motion
-	 * @details    Use this function in situations when the force axis needs to
-	 *             be updated (as an estimated normal for example) over time.
-	 *             This does not reset the integral terms. In setting up the
-	 *             controller for the first time, prefer setForceAxis.
-	 *
-	 * @param      force_axis  The axis in robot frame coordinates along which
-	 *                         the controller behaves as a force controller.
+	 * @brief Parametrizes the moment space and rotational motion space.
+	 * The first argument is the dimension of the moment space (between
+	 * 0 and 3, 0 meaning the whole rotation is controlled in motion and 3
+	 * meaning the whole rotation is controlled in moments) and the second
+	 * argument is the axis defining the space of dimension one (unused if the
+	 * first parameter is 0 or 3, and representing the direction of the moment
+	 * space is the first parameter is 1, or the direction of the rotational motion space
+	 * if the first parameter is 2)
+	 * 
+	 * @param moment_space_dimension betawwn 0 and 3
+	 * @param moment_or_rot_motion_single_axis non singular axis (unused if
+	 * moment_space_dimension is 0 or 3)
 	 */
-	void updateForceAxis(const Vector3d force_axis);
+	void parametrizeMomentRotMotionSpaces(
+		const int moment_space_dimension,
+		const Vector3d& moment_or_rot_motion_single_axis = Vector3d::Zero());
 
-	/**
-	 * @brief      Sets the motion controlled axis for a hybrid position force
-	 *             controller with 2 DoF force and 1 DoF motion
-	 * @details    This is the function to use in order to get the position part
-	 *             of the controller behave as a Hybrid Force/Motion controller
-	 *             with 2 Dof force. The motion is controlled along one axis and
-	 *             the force is controlled orthogonally to the motion It can be
-	 *             called anytime to change the behavior of the controller and
-	 *             reset the integral terms.
-	 *
-	 * @param[in]  motion_axis  The motion axis
-	 * @param      force_axis  The axis in robot frame coordinates along which the
-	 *                         controller behaves as a motion controller.
-	 */
-	void setLinearMotionAxis(const Vector3d motion_axis);
 
-	/**
-	 * @brief      Sets the motion controlled axis for a hybrid position force
-	 *             controller with 2 DoF force and 1 DoF motion
-	 * @details    Use this function in situations when the motion axis needs to
-	 *             be updated over time. This does not reset the integral terms.
-	 *             In setting up the controller for the first time, prefer
-	 *             setMotionAxis.
-	 *
-	 * @param[in]  motion_axis  The motion axis
-	 * @param      force_axis  The axis in robot frame coordinates along which the
-	 *                         controller behaves as a motion controller.
-	 */
-	void updateLinearMotionAxis(const Vector3d motion_axis);
-
-	/**
-	 * @brief      Sets the linear part of the task as a full 3DoF force
-	 *             controller
-	 * @details    This is the function to use in order to get the position part
-	 *             of the controller behave as pure Force controller with 3 Dof
-	 *             force. It can be called anytime to change the behavior of the
-	 *             controller and reset the integral terms.
-	 */
-	void setFullForceControl();
-
-	/**
-	 * @brief      Sets the linear part of the task as a full 3DoF motion
-	 *             controller
-	 * @details    This is the function to use in order to get the position part
-	 *             of the controller behave as pure Motion controller with 3 Dof
-	 *             linear motion. It is de default behavior of the controller.
-	 *             It can be called anytime to change the behavior of the
-	 *             controller and reset the integral terms.
-	 */
-	void setFullLinearMotionControl();
-
-	/**
-	 * @brief      Sets the moment controlled axis for a hybrid orientation
-	 *             moment controller with 1 DoF moment and 2 DoF orientation
-	 * @details    This is the function to use in order to get the orientation
-	 *             part of the controller behave as a Hybrid Force/Motion
-	 *             controller with 1 Dof moment. The rotational motion is
-	 *             controlled orthogonally to the moment. 
-	 *             
-	 *             It can be called anytime to change the behavior of the controller 
-	 *             and reset the integral terms.
-	 *
-	 * @param      moment_axis  The axis in robot frame coordinates along
-	 *                          which the controller behaves as a moment
-	 *                          controller.
-	 */
-	void setMomentAxis(const Vector3d moment_axis);
-
-	/**
-	 * @brief      Sets the moment controlled axis for a hybrid orientation
-	 *             moment controller with 1 DoF moment and 2 DoF orientation
-	 * @details    Use this function in situations when the moment axis needs to
-	 *             be updated over time. This does not reset the integral terms.
-	 *             
-	 *             In setting up the controller for the first time, prefer
-	 *             setMomentAxis.
-	 *
-	 * @param      moment_axis  The axis in robot frame coordinates along
-	 *                          which the controller behaves as a moment
-	 *                          controller.
-	 */
-	void updateMomentAxis(const Vector3d moment_axis);
-
-	/**
-	 * @brief      Sets the angular movement controlled axis for a hybrid
-	 *             orientation moment controller with 2 DoF moment and 1 DoF
-	 *             motion
-	 * @details    This is the function to use in order to get the orientation
-	 *             part of the controller behave as a Hybrid Force/Motion
-	 *             controller with 2 Dof moment. The rotational motion is
-	 *             controlled along one axis and the moment is controlled
-	 *             orthogonally to the motion.
-	 *             
-	 *             It can be called anytime to change
-	 *             the behavior of the controller and reset the integral terms.
-	 *
-	 * @param[in]  motion_axis  The motion axis
-	 * @param      force_axis  The axis in robot frame coordinates along which the
-	 *                         controller behaves as a rotational motion controller.
-	 */
-	void setAngularMotionAxis(const Vector3d motion_axis);
-
-	/**
-	 * @brief      Sets the angular movement controlled axis for a hybrid
-	 *             orientation moment controller with 2 DoF moment and 1 DoF
-	 *             motion
-	 * @details    Use this function in situations when the angular motion axis
-	 *             needs to be updated over time. This does not reset the
-	 *             integral terms. 
-	 *             
-	 *             In setting up the controller for the first
-	 *             time, prefer setAngularMotionAxis.
-	 *
-	 * @param[in]  motion_axis  The motion axis
-	 * @param      force_axis  The axis in robot frame coordinates along which the
-	 *                         controller behaves as a rotational motion controller.
-	 */
-	void updateAngularMotionAxis(const Vector3d motion_axis);
-
-	/**
-	 * @brief      Sets the angular part of the task as a full 3DoF moment
-	 *             controller
-	 * @details    This is the function to use in order to get the orientation
-	 *             part of the controller behave as pure moment controller with
-	 *             3 Dof moment. It can be called anytime to change the behavior
-	 *             of the controller and reset the integral terms.
-	 */
-	void setFullMomentControl();
-
-	/**
-	 * @brief      Sets the angular part of the task as a full 3DoF motion
-	 *             controller
-	 * @details    This is the function to use in order to get the orientation
-	 *             part of the controller behave as pure Motion controller with
-	 *             3 Dof angular motion. It is de default behavior of the
-	 *             controller. It can be called anytime to change the behavior
-	 *             of the controller and reset the integral terms.
-	 */
-	void setFullAngularMotionControl();
+	Matrix3d sigmaForce() const;
+	Matrix3d sigmaMoment() const;
 
 	/**
 	 * @brief      Changes the behavior to closed loop force/moment control for the
 	 *             force controlled directions in the linear/angular parts of the
 	 *             controller
 	 */
-	void setClosedLoopForceControl();
-	void setOpenLoopForceControl();
-	void setClosedLoopMomentControl();
-	void setOpenLoopMomentControl();
+	void setClosedLoopForceControl(const bool closed_loop_force_control = true) {
+		_closed_loop_force_control = closed_loop_force_control;
+		resetIntegratorsLinear();
+	}
+	void setClosedLoopMomentControl(const bool closed_loop_moment_control = true) {
+		_closed_loop_moment_control = closed_loop_moment_control;
+		resetIntegratorsAngular();
+	}
 
 	/**
 	 * @brief      Enables or disables the passivity based stability for the closed loop
 	 *             force control (enabled by default)
 	 */
-	void enablePassivity();
-	void disablePassivity();
+	void enablePassivity() { _POPC_force->enable(); }
+	void disablePassivity() { _POPC_force->disable(); }
 
 	// ------- helper methods -------
 
@@ -559,18 +442,18 @@ private:
 
 	// gains for motion controller
 	// defaults to 50 for p gains, 14 for d gains and 0 fir i gains
-	double _kp_pos, _kp_ori;
-	double _kv_pos, _kv_ori;
-	double _ki_pos, _ki_ori;
+	Matrix3d _kp_pos, _kp_ori;
+	Matrix3d _kv_pos, _kv_ori;
+	Matrix3d _ki_pos, _ki_ori;
 
 	// gains for the closed loop force controller
 	// by default, the force controller is open loop
 	// to set the behavior to closed loop controller, use the functions setClosedLoopForceControl and setClosedLoopMomentControl.
 	// the closed loop force controller is a PI controller with feedforward force and velocity based damping.
 	// gains default to 1 for p gains, 0.7 for i gains and 10 for d gains
-	double _kp_force, _kp_moment;
-	double _kv_force, _kv_moment;
-	double _ki_force, _ki_moment;
+	Matrix3d _kp_force, _kp_moment;
+	Matrix3d _kv_force, _kv_moment;
+	Matrix3d _ki_force, _ki_moment;
 	
 	// desired force and moment for the force part of the controller
 	// defaults to Zero
@@ -596,7 +479,7 @@ private:
 	// Angular Jerk          - 3PI   Rad/s^3
 #endif
 
-	Sai2Model::Sai2Model* _robot;
+	std::shared_ptr<Sai2Model::Sai2Model> _robot;
 	double _loop_timestep;
 
 	Eigen::VectorXd _task_force;
@@ -604,7 +487,8 @@ private:
 
 	// internal variables, not to be touched by the user
 	string _link_name;
-	Affine3d _control_frame;   // in link_frame
+	Affine3d _compliant_frame;   // in link_frame
+	bool _is_force_motion_parametrization_in_compliant_frame;
 
 	// motion quantities
 	Vector3d _current_position;      // robot frame
@@ -629,6 +513,8 @@ private:
 	Vector3d _integrated_force_error;    // robot frame
 	Vector3d _integrated_moment_error;   // robot frame
 
+	int _force_space_dimension, _moment_space_dimension;
+	Vector3d _force_or_motion_axis, _moment_or_rotmotion_axis;
 	Matrix3d _sigma_force;     // robot frame
 	Matrix3d _sigma_moment;    // robot frame
 
@@ -644,13 +530,13 @@ private:
 	Vector3d _linear_force_control;
 
 	// control parameters
-	bool _use_isotropic_gains_position;                 // defaults to true
-	bool _use_isotropic_gains_orientation;              // defaults to true
-	Matrix3d _kp_pos_mat, _kp_ori_mat;
-	Matrix3d _kv_pos_mat, _kv_ori_mat;
-	Matrix3d _ki_pos_mat, _ki_ori_mat;
+	bool _are_pos_gains_isotropic;        // defaults to true
+	bool _are_ori_gains_isotropic;        // defaults to true
+	// Matrix3d _kp_pos_mat, _kp_ori_mat;
+	// Matrix3d _kv_pos_mat, _kv_ori_mat;
+	// Matrix3d _ki_pos_mat, _ki_ori_mat;
 
-	int _dynamic_decoupling_type = BOUNDED_INERTIA_ESTIMATES;
+	DynamicDecouplingType _dynamic_decoupling_type = BOUNDED_INERTIA_ESTIMATES;
 
 	// model quantities
 	MatrixXd _jacobian;


### PR DESCRIPTION
From now on, the MotionForceTask can be parametrized with respect to the compliant frame, or with respect to the robot base frame. In both cases, the desired position and orientation are given in robot base frame. What changes is:
1  The parametrization of the force and motion space: For example, if setting the force dimension to 1 and the force axis to the Z axis, if the parametrization is done with respect to the robot base, the force axis will not rotate with the end effector, and if the parametrization is done with respect to the compliant frame, the force controlled direction will rotate with the end effector
2  The directions for anisotropic gains will rotate with the compliant frame or not depending on the parametrization

This PR introduces this new way of thinking about the task parametrization and cleans up the API to reduce the number of functions