### PR TITLE
Remove some computations from full joint task

### DIFF
--- a/examples/08-partial_motion_force_task/08-partial_motion_force_task.cpp
+++ b/examples/08-partial_motion_force_task/08-partial_motion_force_task.cpp
@@ -211,10 +211,15 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 					 motion_force_task->getCurrentPosition())
 						.transpose()
 				 << endl;
-			cout << "position error : "
+			cout << "position error in controlled space : "
 				 << (motion_force_task->posSelectionProjector() *
 					 (motion_force_task->getDesiredPosition() -
 					  motion_force_task->getCurrentPosition()))
+						.norm()
+				 << endl;
+			cout << "position error in full space : "
+				 << (motion_force_task->getDesiredPosition() -
+					 motion_force_task->getCurrentPosition())
 						.norm()
 				 << endl;
 			cout << endl;

--- a/examples/09-3d_position_force_controller/09-3d_position_force_controller.cpp
+++ b/examples/09-3d_position_force_controller/09-3d_position_force_controller.cpp
@@ -154,11 +154,11 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 
 		// move in x and y plane back and forth
 		if (timer.elapsedCycles() % 2000 == 0) {
-			desired_position(0) += 0.07;
-			desired_position(1) += 0.07;
-		} else if (timer.elapsedCycles() % 2000 == 1000) {
 			desired_position(0) -= 0.07;
 			desired_position(1) -= 0.07;
+		} else if (timer.elapsedCycles() % 2000 == 1000) {
+			desired_position(0) += 0.07;
+			desired_position(1) += 0.07;
 		}
 		if (timer.elapsedCycles() > 2000 && timer.elapsedCycles() < 3000) {
 			desired_position(2) -= 0.00015;

--- a/src/RobotController.cpp
+++ b/src/RobotController.cpp
@@ -59,8 +59,7 @@ Eigen::VectorXd RobotController::computeControlTorques() {
 		control_torques += task->computeTorques() - previous_tasks_disturbance;
 	}
 	previous_tasks_disturbance =
-		(MatrixXd::Identity(dof, dof) -
-		 _redundancy_completion_task->getTaskNullspace().transpose()) *
+		_redundancy_completion_task->getPreviousTasksNullspace().transpose() *
 		control_torques;
 	control_torques += _redundancy_completion_task->computeTorques() -
 					   previous_tasks_disturbance;

--- a/src/tasks/JointTask.h
+++ b/src/tasks/JointTask.h
@@ -163,6 +163,13 @@ public:
 	MatrixXd getTaskNullspace() const override { return _N; }
 
 	/**
+	 * @brief Get the Nullspace projector of the previous tasks
+	 *
+	 * @return Eigen::MatrixXd
+	 */
+	MatrixXd getPreviousTasksNullspace() const override { return _N_prec; }
+
+	/**
 	 * @brief Get the nullspace of this and the previous tasks. Concretely, it
 	 * is the task nullspace multiplied by the nullspace of the previous tasks
 	 *
@@ -341,9 +348,10 @@ private:
 	MatrixXd _joint_selection;	// selection matrix for the joint task, defaults
 								// to Identity
 	MatrixXd _projected_jacobian;
-	MatrixXd _Jbar;
 	MatrixXd _N;
 	MatrixXd _current_task_range;
+
+	bool _is_partial_joint_task;
 };
 
 } /* namespace Sai2Primitives */

--- a/src/tasks/MotionForceTask.h
+++ b/src/tasks/MotionForceTask.h
@@ -130,12 +130,19 @@ public:
 	const Vector3d& getSensedMoment() const { return _sensed_moment; }
 
 	/**
-	 * @brief Get the nullspace of this task. Will be 0 if ths
-	 * is a full joint task
+	 * @brief Get the nullspace of this task associated with the constrained,
+	 * reduced jacobian
 	 *
 	 * @return const MatrixXd& Nullspace matrix
 	 */
 	MatrixXd getTaskNullspace() const override { return _N; }
+
+	/**
+	 * @brief Get the Nullspace projector of the previous tasks
+	 *
+	 * @return Eigen::MatrixXd
+	 */
+	MatrixXd getPreviousTasksNullspace() const override { return _N_prec; }
 
 	/**
 	 * @brief Get the nullspace of this and the previous tasks. Concretely, it

--- a/src/tasks/TemplateTask.h
+++ b/src/tasks/TemplateTask.h
@@ -49,25 +49,34 @@ public:
 	virtual Eigen::VectorXd computeTorques() = 0;
 
 	/**
-	 * @brief Re initializes the task by setting the desired state to the current state.
-	 * 
+	 * @brief Re initializes the task by setting the desired state to the
+	 * current state.
+	 *
 	 */
 	virtual void reInitializeTask() = 0;
 
-    /**
-     * @brief Get the Nullspace projector of this task
-     * 
-     * @return Eigen::MatrixXd
-     */
-    virtual Eigen::MatrixXd getTaskNullspace() const = 0;
+	/**
+	 * @brief Get the Nullspace projector of this task only (N associated with
+	 * the jacobian or constrained jacobian of this task)
+	 *
+	 * @return Eigen::MatrixXd
+	 */
+	virtual Eigen::MatrixXd getTaskNullspace() const = 0;
 
-    /**
-     * @brief Get the Nullspace projector of this task and the previous tasks
-     * 
-     * @return Eigen::MatrixXd
-     */
-	virtual Eigen::MatrixXd getTaskAndPreviousNullspace() const =0;
+	/**
+	 * @brief Get the Nullspace projector of the previous tasks (N_prec
+	 * associated with all the previous tasks)
+	 *
+	 * @return Eigen::MatrixXd
+	 */
+	virtual Eigen::MatrixXd getPreviousTasksNullspace() const = 0;
 
+	/**
+	 * @brief Get the Nullspace projector of this task and the previous tasks (N * N_prec)
+	 *
+	 * @return Eigen::MatrixXd
+	 */
+	virtual Eigen::MatrixXd getTaskAndPreviousNullspace() const = 0;
 
 	/**
 	 * @brief gets a const reference to the internal robot model


### PR DESCRIPTION
full joint task does not perform the SVD anymore and uses the full mass matrix and full Identity jacobian