### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ The examples depend on additional libraries : sai2-simulation, sai2-graphics, sa
 ## Build instructions
 First build ruckig:
 ```
-cd third_party/ruckig
+cd ruckig
 mkdir build && cd build
 cmake .. && make -j4
-cd ../../..
+cd ../..
 ```
 Next, build sai2-primitives
 ```


### PR DESCRIPTION
Very minor typo correction, README implies ruckig is located an additional folder level down in a folder called third_party but it is not located there and third_party folder doesn't exist