### PR TITLE
Cleanup on joint task and robot controller

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.10)
 project(SAI2-PRIMITIVES)
 set(PROJECT_VERSION 0.1.0)
 
-set(CMAKE_CXX_FLAGS "-std=c++17 -I/usr/include -I/usr/local/include -fPIC -O2")
+set(CMAKE_CXX_FLAGS "-std=c++17 -I/usr/include -I/usr/local/include -fPIC")
 if(${CMAKE_SYSTEM_NAME} MATCHES Darwin)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I/opt/homebrew/include")
 endif()
@@ -16,6 +16,10 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
       CACHE STRING "Choose the type of build." FORCE)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
                                                "MinSizeRel" "RelWithDebInfo")
+endif()
+
+if(CMAKE_BUILD_TYPE STREQUAL "Release")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
 endif()
 
 # include Eigen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.10)
 project(SAI2-PRIMITIVES)
 set(PROJECT_VERSION 0.1.0)
 
+option(BUILD_EXAMPLES "Build examples" ON)
+
 set(CMAKE_CXX_FLAGS "-std=c++17 -I/usr/include -I/usr/local/include -fPIC")
 if(${CMAKE_SYSTEM_NAME} MATCHES Darwin)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I/opt/homebrew/include")
@@ -50,7 +52,8 @@ set(HELPER_MODULES_SOURCE
     ${PROJECT_SOURCE_DIR}/src/helper_modules/POPCExplicitForceControl.cpp
     ${PROJECT_SOURCE_DIR}/src/helper_modules/OTG_joints.cpp
     ${PROJECT_SOURCE_DIR}/src/helper_modules/OTG_6dof_cartesian.cpp
-    ${PROJECT_SOURCE_DIR}/src/helper_modules/Sai2PrimitivesCommonDefinitions.cpp)
+    ${PROJECT_SOURCE_DIR}/src/helper_modules/Sai2PrimitivesCommonDefinitions.cpp
+)
 
 # add header files
 set(SAI2-PRIMITIVES_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/src
@@ -95,4 +98,6 @@ write_basic_package_version_file(
   COMPATIBILITY SameMajorVersion)
 
 # add examples
-add_subdirectory(${PROJECT_SOURCE_DIR}/examples)
+if(BUILD_EXAMPLES)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/examples)
+endif()

--- a/examples/05-using_robot_controller/05-using_robot_controller.cpp
+++ b/examples/05-using_robot_controller/05-using_robot_controller.cpp
@@ -122,9 +122,12 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 		robot->positionInWorld(link_name, pos_in_link);
 	const VectorXd initial_q = robot->q();
 
+	// joint task in the nullspace of the motion-force task
+	auto joint_task = make_shared<Sai2Primitives::JointTask>(robot);
+
 	// robot controller to automatize the task update and control computation
 	vector<shared_ptr<Sai2Primitives::TemplateTask>> task_list = {
-		motion_force_task};
+		motion_force_task, joint_task};
 	auto robot_controller =
 		make_unique<Sai2Primitives::RobotController>(robot, task_list);
 
@@ -182,7 +185,7 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 		if (timer.elapsedCycles() == 5000) {
 			VectorXd goal_joint_pos = initial_q;
 			goal_joint_pos(0) += 1.5;
-			robot_controller->getRedundancyCompletionTask()->setGoalPosition(
+			joint_task->setGoalPosition(
 				goal_joint_pos);
 		}
 

--- a/examples/08-partial_motion_force_task/08-partial_motion_force_task.cpp
+++ b/examples/08-partial_motion_force_task/08-partial_motion_force_task.cpp
@@ -135,11 +135,14 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 	Matrix3d goal_orientation = initial_orientation;
 
 	// joint task to control the nullspace
+	auto joint_task = make_shared<Sai2Primitives::JointTask>(robot);
+
+	// controller
 	vector<shared_ptr<Sai2Primitives::TemplateTask>> task_list = {
-		motion_force_task};
+		motion_force_task, joint_task};
 	auto robot_controller =
 		make_unique<Sai2Primitives::RobotController>(robot, task_list);
-	robot_controller->getRedundancyCompletionTask()->setGains(100.0, 20.0);
+	joint_task->setGains(100.0, 20.0);
 
 	// create a loop timer
 	double control_freq = 1000;
@@ -184,8 +187,7 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 		if (timer.elapsedCycles() == 8000) {
 			VectorXd q_des = robot->q();
 			q_des(0) += 0.5;
-			robot_controller->getRedundancyCompletionTask()->setGoalPosition(
-				q_des);
+			joint_task->setGoalPosition(q_des);
 		}
 
 		motion_force_task->setGoalPosition(goal_position);

--- a/examples/09-3d_position_force_controller/09-3d_position_force_controller.cpp
+++ b/examples/09-3d_position_force_controller/09-3d_position_force_controller.cpp
@@ -126,8 +126,11 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 	Vector3d goal_position = initial_position;
 
 	// joint task to control the nullspace
+	auto joint_task = make_shared<Sai2Primitives::JointTask>(robot);
+
+	// controller
 	vector<shared_ptr<Sai2Primitives::TemplateTask>> task_list = {
-		motion_force_task};
+		motion_force_task, joint_task};
 	auto robot_controller =
 		make_unique<Sai2Primitives::RobotController>(robot, task_list);
 

--- a/examples/10-3d_orientation_controller/10-3d_orientation_controller.cpp
+++ b/examples/10-3d_orientation_controller/10-3d_orientation_controller.cpp
@@ -119,8 +119,9 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 	Matrix3d goal_orientation = initial_orientation;
 
 	// robot controller
+	auto joint_task = make_shared<Sai2Primitives::JointTask>(robot);
 	vector<shared_ptr<Sai2Primitives::TemplateTask>> task_list = {
-		motion_force_task};
+		motion_force_task, joint_task};
 	auto robot_controller =
 		make_unique<Sai2Primitives::RobotController>(robot, task_list);
 

--- a/examples/11-planar_robot_controller/11-planar_robot_controller.cpp
+++ b/examples/11-planar_robot_controller/11-planar_robot_controller.cpp
@@ -122,8 +122,9 @@ void control(shared_ptr<Sai2Model::Sai2Model> robot,
 	Matrix3d goal_orientation = initial_orientation;
 
 	// robot controller with the motion force task
+	auto joint_task = make_shared<Sai2Primitives::JointTask>(robot);
 	vector<shared_ptr<Sai2Primitives::TemplateTask>> task_list = {
-		motion_force_task};
+		motion_force_task, joint_task};
 	auto robot_controller =
 		make_unique<Sai2Primitives::RobotController>(robot, task_list);
 

--- a/examples/15-haptic_control_impedance_type/15-haptic_control_impedance_type.cpp
+++ b/examples/15-haptic_control_impedance_type/15-haptic_control_impedance_type.cpp
@@ -157,8 +157,9 @@ void runControl(shared_ptr<Sai2Simulation::Sai2Simulation> sim) {
 	motion_force_task->setOriControlGains(400.0, 40.0);
 	Vector3d prev_sensed_force = Vector3d::Zero();
 
+	auto joint_task = make_shared<Sai2Primitives::JointTask>(robot);
 	vector<shared_ptr<Sai2Primitives::TemplateTask>> task_list = {
-		motion_force_task};
+		motion_force_task, joint_task};
 	auto robot_controller =
 		make_unique<Sai2Primitives::RobotController>(robot, task_list);
 

--- a/examples/16-haptic_control_admittance_type/16-haptic_control_admittance_type.cpp
+++ b/examples/16-haptic_control_admittance_type/16-haptic_control_admittance_type.cpp
@@ -144,8 +144,9 @@ void runControl(shared_ptr<Sai2Simulation::Sai2Simulation> sim) {
 	motion_force_task->disableInternalOtg();
 	motion_force_task->enableVelocitySaturation(0.7, M_PI);
 
+	auto joint_task = make_shared<Sai2Primitives::JointTask>(robot);
 	vector<shared_ptr<Sai2Primitives::TemplateTask>> task_list = {
-		motion_force_task};
+		motion_force_task, joint_task};
 	auto robot_controller =
 		make_unique<Sai2Primitives::RobotController>(robot, task_list);
 

--- a/examples/17-bilateral_teleop_with_POPC/17-bilateral_teleop_with_POPC.cpp
+++ b/examples/17-bilateral_teleop_with_POPC/17-bilateral_teleop_with_POPC.cpp
@@ -158,8 +158,9 @@ void runControl(shared_ptr<Sai2Simulation::Sai2Simulation> sim) {
 	motion_force_task->setOriControlGains(200.0, 25.0);
 	Vector3d prev_sensed_force = Vector3d::Zero();
 
+	auto joint_task = make_shared<Sai2Primitives::JointTask>(robot);
 	vector<shared_ptr<Sai2Primitives::TemplateTask>> task_list = {
-		motion_force_task};
+		motion_force_task, joint_task};
 	auto robot_controller =
 		make_unique<Sai2Primitives::RobotController>(robot, task_list);
 

--- a/src/RobotController.h
+++ b/src/RobotController.h
@@ -34,10 +34,6 @@ public:
 
 	void reinitializeTasks();
 
-	std::shared_ptr<JointTask> getRedundancyCompletionTask() {
-		return _redundancy_completion_task;
-	}
-
 	std::shared_ptr<JointTask> getJointTaskByName(const std::string& task_name);
 	std::shared_ptr<MotionForceTask> getMotionForceTaskByName(const std::string& task_name);
 
@@ -49,7 +45,6 @@ private:
     std::shared_ptr<Sai2Model::Sai2Model> _robot;
 	std::vector<std::shared_ptr<TemplateTask>> _tasks;
 	std::vector<std::string> _task_names;
-	std::shared_ptr<JointTask> _redundancy_completion_task;
 	bool _enable_gravity_compensation;
 };
 

--- a/src/tasks/JointTask.h
+++ b/src/tasks/JointTask.h
@@ -112,6 +112,7 @@ public:
 	const MatrixXd getJointSelectionMatrix() const { return _joint_selection; }
 
 	int getTaskDof() const { return _task_dof; }
+	bool isFullJointTask() const { return _task_dof == getConstRobotModel()->dof(); }
 
 	/**
 	 * @brief Get the Current Position
@@ -448,8 +449,6 @@ private:
 	MatrixXd _projected_jacobian;
 	MatrixXd _N;
 	MatrixXd _current_task_range;
-
-	bool _is_partial_joint_task;
 };
 
 } /* namespace Sai2Primitives */


### PR DESCRIPTION
Removed automatic redundancy resolution task from RobotController because it is more clear if it has to be set manually, and it is very easy to setup with a JointTask with default parametrization

Joint task now uses the reduced projected jacobian, even is it is a full task